### PR TITLE
chore: set package publish to public

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -35,7 +35,7 @@ jobs:
     needs: version
     uses: parcelLab/ci/.github/workflows/npm.yaml@v1
     with:
-      # buildBeforePublish: false # For packages that do not require a build step
+      access: public
       version: ${{ needs.version.outputs.version }}
     secrets:
       githubAuthToken: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 //npm.pkg.github.com/:_authToken=${NPM_GITHUB_TOKEN}
-@parcellab:registry=https://npm.pkg.github.com
 engine-strict=true


### PR DESCRIPTION
This should publish the package to the public npm repository.

We need to test if there will be any clash with the private packages, but it should work.

When providing the `access: public` flag, it will push both to the private npm repoe (github) and to the public npm, so it is available in both (this is to ensure that any private repositories will get our open source under the `@parcellab` scope without having to define two different scopes)