### PR TITLE
ci: set REPO_ACCESS_TOKEN_OPEN_SOURCE in ci

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -24,4 +24,4 @@ jobs:
       - verify
     uses: parcelLab/ci/.github/workflows/release.yaml@v1
     secrets:
-      repoAccessToken: ${{ secrets.REPO_ACCESS_TOKEN }}
+      repoAccessToken: ${{ secrets.REPO_ACCESS_TOKEN_OPEN_SOURCE }}

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -38,4 +38,4 @@ jobs:
       access: public
       version: ${{ needs.version.outputs.version }}
     secrets:
-      githubAuthToken: ${{ secrets.REPO_ACCESS_TOKEN }}
+      githubAuthToken: ${{ secrets.REPO_ACCESS_TOKEN_OPEN_SOURCE }}


### PR DESCRIPTION
The other secret is only available for private repositories.