### PR TITLE
ci: add npm token

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -39,3 +39,4 @@ jobs:
       version: ${{ needs.version.outputs.version }}
     secrets:
       githubAuthToken: ${{ secrets.REPO_ACCESS_TOKEN_OPEN_SOURCE }}
+      npmjsAuthToken: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I see that in eslint-config we do use that npm token